### PR TITLE
DSP-1771: Add Oracle driver to Zeppelin notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ notebook
 *~
 spark*
 zeppelin
+oracle
 local-repo
 conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,41 @@ RUN \
     libglib2.0-0 \
     libxext6 \
     libsm6 \
-    libxrender1 && \
+    libxrender1 \
+    libaio1 \
+    build-essential \
+    unzip && \
   apt-get clean all
+
+# INSTALL ORACLE INSTANT CLIENT
+RUN mkdir -p opt/oracle
+ADD ./oracle/linux/ .
+RUN unzip instantclient-basic-linux.x64.zip -d /opt/oracle \
+ && unzip instantclient-sdk-linux.x64.zip -d /opt/oracle  \
+ && unzip instantclient-sqlplus-linux.x64.zip -d /opt/oracle \
+ && mv /opt/oracle/instantclient_* /opt/oracle/instantclient \
+ && ln -s /opt/oracle/instantclient/libclntsh.so.* /opt/oracle/instantclient/libclntsh.so \
+ && ln -s /opt/oracle/instantclient/libocci.so.* /opt/oracle/instantclient/libocci.so
+RUN mkdir -p opt/oracle/instantclient/network/admin
+
+ENV OCI_HOME="/opt/oracle/instantclient"
+ENV OCI_LIB_DIR="/opt/oracle/instantclient"
+ENV OCI_INCLUDE_DIR="/opt/oracle/instantclient/sdk/include"
+ENV OCI_VERSION=12
+ENV LD_LIBRARY_PATH="/opt/oracle/instantclient"
+ENV TNS_ADMIN="/opt/oracle/instantclient"
+ENV ORACLE_BASE="/opt/oracle/instantclient"
+ENV ORACLE_HOME="/opt/oracle/instantclient"
+ENV PATH="/opt/oracle/instantclient:$PATH"
+RUN echo '/opt/oracle/instantclient/' | tee -a /etc/ld.so.conf.d/oracle_instant_client.conf && ldconfig
+
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
   wget --quiet https://repo.continuum.io/archive/Anaconda2-4.2.0-Linux-x86_64.sh -O ~/anaconda.sh && \
   /bin/bash ~/anaconda.sh -b -p /opt/conda && \
   rm ~/anaconda.sh
 
-RUN /opt/conda/bin/conda install SQLAlchemy psycopg2 pymssql
+RUN /opt/conda/bin/conda install SQLAlchemy psycopg2 pymssql cx_Oracle
 RUN ln -s /opt/conda/bin/python /usr/bin/python
 
 ADD spark /usr/local/spark

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ SQL databases are supported trough [SQLAlchemy](https://docs.sqlalchemy.org/en/l
 | ------- | --------- |
 | `pymssql` | Microsoft SQL Server |
 | `psycopg2` | PostgreSQL |
+| `cx_Oracle` | Oracle |
 
 Support for additional databases can be added by installing additional [dialects](https://docs.sqlalchemy.org/en/latest/dialects/) into an anaconda environment and setting `ZEPPELIN_PYSPARK_PYTHON` to the environment location.
 
@@ -97,6 +98,19 @@ conn_str = "postgresql+psycopg2:///<User>:<Password>@<Host>:<Port>"
 engine = create_engine(conn_str)
 # List All DBs
 res = engine.execute('SELECT * FROM pg_database')
+for row in res:
+    print row
+```
+
+###  Oracle Example
+
+```
+%spark.pyspark
+import sqlalchemy
+from sqlalchemy import create_engine
+conn_str = "oracle+cx_oracle:///<User>:<Password>@<Host>:<Port>/<db>"
+engine = create_engine(conn_str)
+res = engine.execute('SELECT * FROM my_table')
 for row in res:
     print row
 ```

--- a/build
+++ b/build
@@ -36,7 +36,23 @@ zeppelin_hadoop_version="$hadoop_version"
 
 zeppelin_version="$3"
 
+oracle_instantclient_version=${4:-12.2.0.1.0}
+
 set -e -v
+
+mkdir -p ./oracle/linux
+
+curl \
+    -L -o oracle/linux/instantclient-sdk-linux.x64.zip \
+    -s https://github.com/bumpx/oracle-instantclient/raw/master/instantclient-sdk-linux.x64-$oracle_instantclient_version.zip
+
+curl \
+    -L -o oracle/linux/instantclient-sqlplus-linux.x64.zip \
+    -s https://github.com/bumpx/oracle-instantclient/raw/master/instantclient-sqlplus-linux.x64-$oracle_instantclient_version.zip
+
+curl \
+    -L -o oracle/linux/instantclient-basic-linux.x64.zip \
+    -s https://github.com/bumpx/oracle-instantclient/raw/master/instantclient-basic-linux.x64-$oracle_instantclient_version.zip
 
 curl -s http://archive.apache.org/dist/spark/spark-$spark_version/spark-$spark_version-bin-hadoop$hadoop_version.tgz | tar -xz -C .
 mv spark-* spark
@@ -48,9 +64,9 @@ if [ "$zeppelin_spark_version" == "2.3" ]
 then
   # https://github.com/apache/zeppelin/pull/2880
   # ./dev/change_scala_version.sh 2.11
-  mvn clean package -DskipTests -Pbuild-distr | perl -ne 'print if $. % 10 == 1'
+  mvn -e clean package -DskipTests -Pbuild-distr | perl -ne 'print if $. % 10 == 1'
 else
-  mvn clean package -Pspark-$zeppelin_spark_version -Phadoop-$zeppelin_hadoop_version -DskipTests -Pbuild-distr | perl -ne 'print if $. % 100 == 1'
+  mvn -e clean package -Pspark-$zeppelin_spark_version -Phadoop-$zeppelin_hadoop_version -DskipTests -Pbuild-distr | perl -ne 'print if $. % 100 == 1'
 fi
 cd ..
 mv zeppelin/zeppelin-distribution/target/zeppelin-*.tar.gz zeppelin_dist.tar.gz


### PR DESCRIPTION
- Updated build with additional argument oracle_instantclient_version that defaults to 12.2.0.1.0.
- Updated build script to download all files required to install oracle instantclient
- Updated Dockerfile to install oracle instantclient